### PR TITLE
Fix flaky tests

### DIFF
--- a/easy-retry-extensions/easy-retry-mybatis-extension/src/test/java/com/alibaba/easyretry/extension/mybatis/access/MybatisRetryTaskAccessTest.java
+++ b/easy-retry-extensions/easy-retry-mybatis-extension/src/test/java/com/alibaba/easyretry/extension/mybatis/access/MybatisRetryTaskAccessTest.java
@@ -39,6 +39,7 @@ class MybatisRetryTaskAccessTest {
 	@Test
 	@Order(2)
 	void handle() {
+		ACCESS.saveRetryTask(task);
 		Assertions.assertTrue(ACCESS.handlingRetryTask(task));
 		List<RetryTask> retryTasks = ACCESS.listAvailableTasks(1L);
 		Assertions.assertTrue(Objects.nonNull(retryTasks) && !retryTasks.isEmpty());
@@ -48,6 +49,7 @@ class MybatisRetryTaskAccessTest {
 	@Test
 	@Order(3)
 	void stop() {
+		ACCESS.saveRetryTask(task);
 		boolean b = ACCESS.stopRetryTask(task);
 		Assertions.assertTrue(b);
 		List<RetryTask> retryTasks = ACCESS.listAvailableTasks(1L);
@@ -57,6 +59,7 @@ class MybatisRetryTaskAccessTest {
 	@Test
 	@Order(4)
 	void finish(){
+		ACCESS.saveRetryTask(task);
 		Assertions.assertTrue(ACCESS.finishRetryTask(task));
 		List<RetryTask> retryTasks = ACCESS.listAvailableTasks(1L);
 		Assertions.assertTrue(Objects.isNull(retryTasks) || retryTasks.isEmpty());

--- a/easy-retry-extensions/easy-retry-mybatis-extension/src/test/java/com/alibaba/easyretry/extension/mybatis/dao/RetryTaskDAOImplTest.java
+++ b/easy-retry-extensions/easy-retry-mybatis-extension/src/test/java/com/alibaba/easyretry/extension/mybatis/dao/RetryTaskDAOImplTest.java
@@ -37,11 +37,21 @@ class RetryTaskDAOImplTest {
 	@Test
 	@Order(2)
 	void listRetryTask() {
+		final RetryTaskPO retryTaskPO = new RetryTaskPO()
+			.setId(1L)
+			.setGmtCreate(new Date())
+			.setBizId("1")
+			.setRetryStatus(RetryTaskStatusEnum.HANDLING.getCode())
+			.setGmtModified(new Date());
+
+		retryTaskDAO.saveRetryTask(retryTaskPO);
 		final RetryTaskQuery retryTaskQuery = new RetryTaskQuery()
 			.setRetryStatus(Collections.singletonList(RetryTaskStatusEnum.HANDLING.getCode()));
 		List<RetryTaskPO> retryTaskPOS = retryTaskDAO.listRetryTask(retryTaskQuery);
 		System.out.println(retryTaskPOS);
-		Assertions.assertTrue(Objects.nonNull(retryTaskPOS) && !retryTaskPOS.isEmpty());
+		Assertions.assertTrue(!retryTaskPOS.isEmpty());
+		Assertions.assertTrue(Objects.nonNull(retryTaskPOS));
+		// Assertions.assertTrue(Objects.nonNull(retryTaskPOS) && !retryTaskPOS.isEmpty());
 	}
 
 	@Test
@@ -67,7 +77,13 @@ class RetryTaskDAOImplTest {
 	@Order(4)
 	void deleteRetryTask() {
 		final RetryTaskPO retryTaskPO = new RetryTaskPO()
-			.setId(1L);
+			.setId(1L)
+			.setGmtCreate(new Date())
+			.setBizId("1")
+			.setRetryStatus(RetryTaskStatusEnum.HANDLING.getCode())
+			.setGmtModified(new Date());
+
+		retryTaskDAO.saveRetryTask(retryTaskPO);
 		boolean b = retryTaskDAO.deleteRetryTask(retryTaskPO);
 		Assertions.assertTrue(b);
 


### PR DESCRIPTION
### Description
Flaky tests are common occurrences in open-source projects, yielding inconsistent results—sometimes passing and sometimes failing—without code changes. I have fixed 5 flaky tests, which are listRetryTask(), deleteRetryTask() in easy-retry/easy-retry-extensions/easy-retry-mybatis-extension/src/test/java/com/alibaba/easyretry/extension/mybatis/dao/RetryTaskDAOImplTest.java and handle(), stop() and finish() in easy-retry/easy-retry-extensions/easy-retry-mybatis-extension/src/test/java/com/alibaba/easyretry/extension/mybatis/access/MybatisRetryTaskAccessTest.java.

### Root cause
The root cause of these flaky tests was related to orders of execution of the tests who locate in the same class. For the RetryTaskDAOImplTest class, it need to run saveTask() firstly, if not, the listRetryTask() and deleteRetryTask() will fail.
For the MybatisRetryTaskAccessTest class, it need to run saveTask() firstly, if not, the tests handle(), stop() and finish() will fail.

### Fix
This test has been resolved by extracting the patches from saveTask() that will create a task and save it firstly, and put the patches in front of the line of assert tests that fail in each order-dependent flaky tests. Then all order-dependent flaky tests pass.

### How to test
Java: openjdk version "11.0.20.1"
Maven: Apache Maven 3.6.3
1. Compile the module
`mvn install -pl easy-retry-extensions/easy-retry-mybatis-extension -am -DskipTests`
2. Run tests for each test
`mvn -pl easy-retry-extensions/easy-retry-mybatis-extension test -Dtest=com.alibaba.easyretry.extension.mybatis.dao.RetryTaskDAOImplTest#listRetryTask`
`mvn -pl easy-retry-extensions/easy-retry-mybatis-extension test -Dtest=com.alibaba.easyretry.extension.mybatis.dao.RetryTaskDAOImplTest#deleteRetryTask`
`mvn -pl easy-retry-extensions/easy-retry-mybatis-extension test -Dtest=com.alibaba.easyretry.extension.mybatis.access.MybatisRetryTaskAccessTest#stop`
`mvn -pl easy-retry-extensions/easy-retry-mybatis-extension test -Dtest=com.alibaba.easyretry.extension.mybatis.access.MybatisRetryTaskAccessTest#finish`
`mvn -pl easy-retry-extensions/easy-retry-mybatis-extension test -Dtest=com.alibaba.easyretry.extension.mybatis.access.MybatisRetryTaskAccessTest#handle`
All tests should pass.

